### PR TITLE
Change estimate type

### DIFF
--- a/lib/views/issues.nokogiri
+++ b/lib/views/issues.nokogiri
@@ -7,7 +7,7 @@ xml.external_stories(:type => "array") do
       xml.requested_by issue["user"]["login"]
       xml.created_at(issue["created_at"], :type => "datetime")
       xml.story_type "bug"
-      xml.estimate 0
+      xml.estimate(0, :type => "float")
     end
   end
 end

--- a/lib/views/issues.nokogiri
+++ b/lib/views/issues.nokogiri
@@ -3,7 +3,7 @@ xml.external_stories(:type => "array") do
     xml.external_story do
       xml.external_id "#{@reponame}/issues/#{issue["number"]}"
       xml.name issue["title"]
-      xml.description issue["description"]
+      xml.description issue["body"]
       xml.requested_by issue["user"]["login"]
       xml.created_at(issue["created_at"], :type => "datetime")
       xml.story_type "bug"


### PR DESCRIPTION
Working with this repo for another project have found a couple of updates needed:
1. Pivotal Tracker now expects the estimate type to be "float" instead of untyped
2. The github issue text is in the "body" node now, not the "description" one.
